### PR TITLE
HDFS multi-datacenter synchronization task

### DIFF
--- a/bin/dumbo
+++ b/bin/dumbo
@@ -72,7 +72,7 @@ CLI.for(Dumbo::CLI) do
   option :mode,
     :short => '-m MODE',
     :long => '--mode MODE',
-    :description => 'mode to perform (verify, compact, unshard)',
+    :description => 'mode to perform (verify, compact, unshard, synchronize)',
     :default => "verify"
 
   option :dryrun,

--- a/lib/dumbo/cli.rb
+++ b/lib/dumbo/cli.rb
@@ -163,7 +163,7 @@ module Dumbo
         end
 
         next unless rebuild
-        @tasks << Task::IndexHadoop.new(source, [slot.time, slot.time+1.hour], slot.patterns, @hadoop_version)
+        @tasks << Task::IndexHadoop.new(source, [slot.time, slot.time+1.hour], slot.pattern, @hadoop_version)
       end
     end
 

--- a/lib/dumbo/cli.rb
+++ b/lib/dumbo/cli.rb
@@ -49,6 +49,12 @@ module Dumbo
           unshard_segments(topic)
         end
         run_tasks
+      when "synchronize"
+        $log.info("synchronizing hdfs")
+        @topics.each do |topic|
+          synchronize(topic)
+        end
+        run_tasks
       else
         $log.error("Unknown mode #{opts[:mode]}, try -h")
       end
@@ -259,6 +265,14 @@ module Dumbo
           $log.info("merging segments", for: interval, segments: segments.length)
           @tasks << Task::Index.new(source, segments.first.interval)
         end
+      end
+    end
+
+    def synchronize(source_name)
+      $log.info("synchronizing hdfs data for", source_name: source_name)
+
+      @hdfs.slots_options!(source_name, @interval).each do |slot_options|
+        slot_options.synchronize! opts[:dryrun]
       end
     end
 

--- a/lib/dumbo/firehose/hdfs.rb
+++ b/lib/dumbo/firehose/hdfs.rb
@@ -73,6 +73,8 @@ module Dumbo
         end
 
         def synchronize!(dryrun = true)
+          $log.info("synchronizing slot options at", time: @time, topic: @topic)
+
           unless @hdfs_servers.size > 1
             $log.info("tried to sync but there are no enough hdfs servers")
             return

--- a/lib/dumbo/firehose/hdfs.rb
+++ b/lib/dumbo/firehose/hdfs.rb
@@ -1,22 +1,24 @@
+require 'fileutils'
 require 'webhdfs'
+require 'webhdfs/fileutils'
 require 'dumbo/time_ext'
 
 module Dumbo
   class Firehose
     class HDFS
       def initialize(namenodes, sources)
+        @hdfs = []
         [namenodes].flatten.each do |host|
           begin
             $log.info("connecting to", namenode: host)
-            @hdfs = WebHDFS::Client.new(host, 50070)
-            @hdfs.list('/')
-            break
+            hdfs = WebHDFS::Client.new(host, 50070)
+            hdfs.list('/')
+            @hdfs << hdfs
           rescue
             $log.info("failed to use", namenode: host)
-            @hdfs = nil
           end
         end
-        raise "no namenode is up and running" unless @hdfs
+        raise "no namenode is up and running" if @hdfs.empty?
         @slots = {}
         @sources = sources
       end
@@ -26,18 +28,106 @@ module Dumbo
       end
 
       def slots!(topic, interval)
-        interval = interval.map { |t| t.floor(1.hour).utc }
         $log.info("scanning HDFS for", interval: interval)
-        interval = (interval.first.to_i..interval.last.to_i)
-        interval.step(1.hour).map do |time|
-          Slot.new(@sources, @hdfs, topic, Time.at(time).utc)
+        enumerable_interval(interval).map do |time|
+          SlotOptions.new(@sources, @hdfs, topic, Time.at(time).utc).best_slot
         end.reject do |slot|
           slot.events.to_i < 1
         end
       end
 
+      def slots_options!(topic, interval)
+        $log.info("scanning HDFS options for", interval: interval)
+        enumerable_interval(interval).map do |time|
+          SlotOptions.new(@sources, @hdfs, topic, Time.at(time).utc)
+        end.reject do |slot|
+          slot.best_slot.events.to_i < 1
+        end
+      end
+
+      def enumerable_interval(interval)
+        interval = interval.map { |t| t.floor(1.hour).utc }
+        interval = (interval.first.to_i..interval.last.to_i)
+        interval.step(1.hour)
+      end
+
+      class SlotOptions
+        attr_reader :topic, :time
+
+        def initialize(sources, hdfs_servers, topic, time)
+          @sources = sources
+          @hdfs_servers = hdfs_servers
+          @topic = topic
+          @time = time
+          @all = all!
+        end
+
+        def all!
+          @hdfs_servers.map do |hdfs|
+            Slot.new(@sources, hdfs, @topic, @time)
+          end
+        end
+
+        def best_slot
+          @all.max_by(&:events)
+        end
+
+        def synchronize!(dryrun = true)
+          unless @hdfs_servers.size > 1
+            $log.info("tried to sync but there are no enough hdfs servers")
+            return
+          end
+
+          all_events = @all.map(&:events).uniq
+          unless all_events.size > 1
+            $log.info("slot already in sync", time: @time, source: @topic)
+            return
+          end
+
+          unless dryrun
+            $log.info("downloading best option", time: @time, from: best_slot.hdfs.host)
+            WebHDFS::FileUtils.set_server(best_slot.hdfs.host, 50070) unless dryrun
+
+            paths = best_slot.paths
+            FileUtils.remove_entry_secure('/tmp/druid-dumbo')
+            FileUtils.mkdir '/tmp/druid-dumbo'
+
+            paths.each do |path|
+              file = path.split('/')[-1]
+              WebHDFS::FileUtils.copy_to_local(path, "/tmp/druid-dumbo/#{file}")
+            end
+          end
+
+          @all.each do |option|
+            next if option == best_slot
+            next if option.events == best_slot.events
+
+            $log.info("found differences between options", delta: (best_slot.events - option.events), best: best_slot.events, current: option.events)
+
+            unless dryrun
+              $log.info("|-- deleting data", at: option.hdfs.host)
+              option.paths.each do |path|
+                option.hdfs.delete(path)
+              end
+
+              $log.info("|-- uploading best option", to: option.hdfs.host)
+              folder = option.pattern.split('/')[0..-2].join('/')
+              WebHDFS::FileUtils.set_server(option.hdfs.host, 50070)
+
+              paths.each do |path|
+                file = path.split('/')[-1]
+                $log.info("|---- copying", file: file, folder: folder, from: best_slot.hdfs.host, to: option.hdfs.host)
+                WebHDFS::FileUtils.copy_from_local("/tmp/druid-dumbo/#{file}", "#{folder}/#{file}")
+              end
+
+              $log.info("|-- sync done", at: option.hdfs.host)
+            end
+          end
+        end
+      end
+
       class Slot
-        attr_reader :topic, :time, :paths, :events
+        attr_reader :hdfs, :topic, :time, :paths, :events
 
         def initialize(sources, hdfs, topic, time)
           @sources = sources
@@ -50,13 +140,13 @@ module Dumbo
           end.reduce(:+)
         end
 
-        def patterns
+        def pattern
           @paths.map do |path|
             tokens = path.split('/')
             suffix = tokens[-1].split('.')
             tokens[-1] = "*.#{suffix[-1]}"
             tokens.join('/')
-          end.compact.uniq.sort
+          end.compact.uniq.sort.first
         end
 
         def paths!
@@ -68,7 +158,7 @@ module Dumbo
                   File.join(path, entry['pathSuffix']) if entry['pathSuffix'] =~ /\.gz$/
                 end
               rescue => e
-                $log.warn("No events in #{path}, ignoring")
+                $log.warn("No events in #{path} at #{@hdfs.host}, ignoring")
                 nil
               end
             end.flatten.compact

--- a/lib/dumbo/task/index_hadoop.rb
+++ b/lib/dumbo/task/index_hadoop.rb
@@ -3,10 +3,10 @@ require 'dumbo/task/base'
 module Dumbo
   module Task
     class IndexHadoop < Base
-      def initialize(source, interval, paths, hadoop_version)
+      def initialize(source, interval, path, hadoop_version)
         @source = source
         @interval = interval
-        @paths = paths
+        @path = path
         @hadoop_version = hadoop_version
       end
 
@@ -43,7 +43,7 @@ module Dumbo
               type: 'hadoop',
               inputSpec: {
                 type: 'static',
-                paths: @paths.join(','),
+                paths: @path,
               },
             },
             tuningConfig: {


### PR DESCRIPTION
Hi,

I added a new task called "synchronize" that given a set of namenodes from different clusters connects to all of them and synchronize its camus data. It finds the biggest segment from each cluster (meaning the one with more events) and copies its data to the others clusters. This is useful to achieve multi-datacenter recovery of segments in druid. 

I modified the Slot class. Now, it represents a particular slot in a particular HDFS, and it is capable of removing and modify its own data. So, for a given hour and topic, there are more than one Slot. I also added the SlotOptions class, which is a collection of all the slots available for a given hour and topic.

Please check it out, and feel free to reply if you have any suggestion or ideas to improve this task.
Thanks!