### PR TITLE
add lag check to verify mode

### DIFF
--- a/bin/dumbo
+++ b/bin/dumbo
@@ -18,7 +18,7 @@ CLI.for(Dumbo::CLI) do
     :short => '-f HOURS',
     :long => '--offset HOURS',
     :description => 'offset from now used as interval end, defaults to 3 hours',
-    :default => 3,
+    :default => 0,
     :proc => Proc.new { |x| x.to_i }
 
   option :topics,

--- a/lib/dumbo/cli.rb
+++ b/lib/dumbo/cli.rb
@@ -20,7 +20,7 @@ module Dumbo
       end
       @topics = opts[:topics] || @sources.keys
       @hdfs = Firehose::HDFS.new(opts[:namenodes], @sources)
-      @interval = [((Time.now.utc-(opts[:window] + opts[:offset]).hours).floor(1.day)).utc, (Time.now.utc-opts[:offset].hour).utc]
+      @interval = [((Time.now.utc-(opts[:window] + opts[:offset]).hours).floor(1.day)).utc, (Time.now.utc-opts[:offset].hour).floor(1.hour).utc]
       @tasks = []
       @limit = opts[:limit]
       @hadoop_version = opts[:hadoop_version]
@@ -95,7 +95,22 @@ module Dumbo
         end
       end
 
-      @hdfs.slots(source_name, @interval).each do |slot|
+      last_non_lagging_slot = validation_interval[0]
+      lag_check = [source['input']['required']].flatten.compact.uniq
+      @hdfs.slots(source_name, @interval).each_with_index do |slot, ii|
+        next if slot.events < 1
+        next unless lag_check.all? do |required_path|
+          slot.paths.any? {|existing_path| existing_path.start_with?(required_path) }
+        end
+        last_non_lagging_slot = slot.time - 1.hour
+      end
+
+      if last_non_lagging_slot != validation_interval[1]
+        $log.info("Last non lagging slot is #{last_non_lagging_slot}")
+        validation_interval[1] = last_non_lagging_slot
+      end
+
+      @hdfs.slots(source_name, validation_interval).each do |slot|
         next if slot.paths.length < 1 || slot.events < 1
 
         segments = @segments.select do |s|

--- a/lib/dumbo/firehose/hdfs.rb
+++ b/lib/dumbo/firehose/hdfs.rb
@@ -68,7 +68,6 @@ module Dumbo
                   File.join(path, entry['pathSuffix']) if entry['pathSuffix'] =~ /\.gz$/
                 end
               rescue => e
-                $log.warn("No events in #{path}, ignoring")
                 nil
               end
             end.flatten.compact

--- a/lib/dumbo/time_ext.rb
+++ b/lib/dumbo/time_ext.rb
@@ -4,4 +4,8 @@ class Time
   def floor(granularity = 1.day)
     Time.at((self.to_f / granularity).floor * granularity)
   end
+
+  def ceil(granularity = 1.day)
+    Time.at((self.to_f / granularity).ceil * granularity)
+  end
 end


### PR DESCRIPTION
This version does the trick, but will do double scanning.

Make sense to change the HDFS caching code to work at path level before deploying.